### PR TITLE
Always treat issues w/ severity "error" as high priority

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/android_lint/parser/LintIssue.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/parser/LintIssue.java
@@ -3,6 +3,8 @@ package org.jenkinsci.plugins.android_lint.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.android.tools.lint.detector.api.Severity;
+
 /** Represents a single issue in a Lint XML file. */
 public class LintIssue {
 
@@ -56,4 +58,10 @@ public class LintIssue {
         locations.add(location);
     }
 
+    public Severity severity() {
+        for (Severity s : Severity.values()) {
+           if (s.getDescription().equals(severity)) return s;
+        }
+        return Severity.WARNING;
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/android_lint/parser/LintParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/android_lint/parser/LintParserTest.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.android_lint.parser;
+
+
+import hudson.plugins.analysis.util.model.FileAnnotation;
+import hudson.plugins.analysis.util.model.Priority;
+import junit.framework.TestCase;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class LintParserTest extends TestCase {
+
+    public void testParser() throws Exception {
+        List<FileAnnotation> annotations = parseResults();
+        assertEquals(3, annotations.size());
+
+        FileAnnotation a1 = annotations.get(0);
+        assertEquals("Call requires API level 8 (current min is 7): android.view.MotionEvent#getActionIndex", a1.getMessage());
+        assertEquals(Priority.HIGH, a1.getPriority());
+        assertEquals("bin/classes/InputObject.class", a1.getFileName());
+        assertEquals("test", a1.getModuleName());
+        assertEquals("NewApi", a1.getType());
+        assertEquals("Unknown", a1.getCategory());
+
+        FileAnnotation a2 = annotations.get(1);
+        assertEquals("The &lt;activity&gt; MonitoredActivity is not registered in the manifest", a2.getMessage());
+        assertEquals(Priority.NORMAL, a2.getPriority());
+        assertEquals("bin/classes/MonitoredActivity.class", a2.getFileName());
+        assertEquals("test", a2.getModuleName());
+        assertEquals("Registered", a2.getType());
+        assertEquals("Unknown", a2.getCategory());
+
+        FileAnnotation a3 = annotations.get(2);
+        assertEquals(Priority.LOW, a3.getPriority());
+        assertEquals("Avoid using &quot;px&quot; as units; use &quot;dp&quot; instead", a3.getMessage());
+        assertEquals("res/layout/foo.xml", a3.getFileName());
+        assertEquals(19, a3.getPrimaryLineNumber());
+    }
+
+    public void testIssueWithSeverityErrorHasHighestPriority() throws  Exception {
+        List<FileAnnotation> annotations = parseResults();
+        FileAnnotation a1 = annotations.get(0);
+        assertEquals(Priority.HIGH, a1.getPriority());
+    }
+
+    private List<FileAnnotation> parseResults() throws InvocationTargetException {
+        LintParser parser = new LintParser("UTF-8");
+        Collection<FileAnnotation> annotations = parser.parse(getClass().getResourceAsStream("lint-results.xml"), "test");
+        return new ArrayList<FileAnnotation>(annotations);
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/android_lint/parser/lint-results.xml
+++ b/src/test/resources/org/jenkinsci/plugins/android_lint/parser/lint-results.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues>
+
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="Call requires API level 8 (current min is 7): android.view.MotionEvent#getActionIndex">
+        <location
+            file="bin/classes/InputObject.class"/>
+    </issue>
+
+    <issue
+        id="Registered"
+        severity="Warning"
+        message="The &lt;activity> MonitoredActivity is not registered in the manifest">
+        <location
+            file="bin/classes/MonitoredActivity.class"/>
+    </issue>
+
+    <issue
+        id="PxUsage"
+        severity="Warning"
+        message="Avoid using &quot;px&quot; as units; use &quot;dp&quot; instead">
+        <location
+            file="res/layout/foo.xml"
+            line="19"
+            column="11"/>
+    </issue>
+</issues>


### PR DESCRIPTION
Example: NewApi has a priority of 6, but severity of "Error". Without this patch it will get flagged as PRIORITY_NORMAL.

This is also useful when overriding the severity of "warning" issues in a custom `lint.xml` file.
