### PR TITLE
Add a possibility to filter issues by path

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintPublisher.java
@@ -33,6 +33,8 @@ public class LintPublisher extends HealthAwarePublisher {
     /** Ant fileset pattern of files to work with. */
     private final String pattern;
 
+    private final String validPathPrefixes;
+
     /**
      * Constructor.
      *
@@ -77,7 +79,7 @@ public class LintPublisher extends HealthAwarePublisher {
             final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
             final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
             final boolean canRunOnFailed, final boolean shouldDetectModules, final boolean canComputeNew,
-            final String pattern) {
+            final String pattern, final String validPathPrefixes) {
         super(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
                 unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
                 unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
@@ -85,6 +87,7 @@ public class LintPublisher extends HealthAwarePublisher {
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, shouldDetectModules, canComputeNew, PLUGIN_NAME);
         this.pattern = pattern;
+        this.validPathPrefixes = validPathPrefixes;
     }
 
     /**
@@ -94,6 +97,10 @@ public class LintPublisher extends HealthAwarePublisher {
      */
     public String getPattern() {
         return pattern;
+    }
+
+    public String getValidPathPrefixes() {
+        return validPathPrefixes;
     }
 
     @Override
@@ -107,7 +114,7 @@ public class LintPublisher extends HealthAwarePublisher {
         logger.log(Messages.AndroidLint_Publisher_CollectingFiles());
         FilesParser lintCollector = new FilesParser(PLUGIN_NAME,
                 StringUtils.defaultIfEmpty(getPattern(), DEFAULT_PATTERN),
-                new LintParser(getDefaultEncoding()), shouldDetectModules(), isMavenBuild(build));
+                new LintParser(getDefaultEncoding(), getValidPathPrefixes()), shouldDetectModules(), isMavenBuild(build));
         ParserResult project = build.getWorkspace().act(lintCollector);
         logger.logLines(project.getLogMessages());
 

--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintReporter.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintReporter.java
@@ -33,6 +33,8 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
     /** Ant fileset pattern of files to work with. */
     private final String pattern;
 
+    private final String validPathPrefixes;
+
     /**
      * Constructor.
      *
@@ -70,7 +72,7 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
             final String unstableNewLow, final String failedTotalAll, final String failedTotalHigh,
             final String failedTotalNormal, final String failedTotalLow, final String failedNewAll,
             final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
-            final boolean canRunOnFailed, final String pattern) {
+            final boolean canRunOnFailed, final String pattern, final String validPathPrefixes) {
         super(healthy, unhealthy, thresholdLimit, useDeltaValues,
                 unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
                 unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
@@ -78,6 +80,7 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, true, PLUGIN_NAME);
         this.pattern = pattern;
+        this.validPathPrefixes = validPathPrefixes;
     }
 
     /**
@@ -87,6 +90,10 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
      */
     public String getPattern() {
         return pattern;
+    }
+
+    public String getValidPathPrefixes() {
+        return validPathPrefixes;
     }
 
     @Override
@@ -99,7 +106,7 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
             final MojoInfo mojo, final PluginLogger logger) throws InterruptedException, IOException {
         FilesParser lintCollector = new FilesParser(PLUGIN_NAME,
                 StringUtils.defaultIfEmpty(getPattern(), DEFAULT_PATTERN),
-                new LintParser(getDefaultEncoding()), getModuleName(pom));
+                new LintParser(getDefaultEncoding(), getValidPathPrefixes()), getModuleName(pom));
         return getTargetPath(pom).act(lintCollector);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/android_lint/parser/LintParser.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/parser/LintParser.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import org.apache.commons.digester.Digester;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.android_lint.Messages;
 import org.xml.sax.SAXException;
 
@@ -33,13 +34,20 @@ public class LintParser extends AbstractAnnotationParser {
 
     private static final long serialVersionUID = 7110868408124058985L;
 
+    private final String[] validPathPrefixes;
+
     /**
      * Creates a parser for Android Lint files.
      *
      * @param defaultEncoding The encoding to use when reading files.
      */
-    public LintParser(final String defaultEncoding) {
+    public LintParser(final String defaultEncoding, final String validPathPrefixes) {
         super(defaultEncoding);
+        if (StringUtils.isEmpty(validPathPrefixes)) {
+            this.validPathPrefixes = new String[0];
+        } else {
+            this.validPathPrefixes = validPathPrefixes.split(",");
+        }
     }
 
     @Override
@@ -165,10 +173,16 @@ public class LintParser extends AbstractAnnotationParser {
     }
 
     private boolean isValidPath(String file) {
-        return file.startsWith("src/") ||
-            file.startsWith("res/") ||
-            file.startsWith("bin/") ||
-            file.equals("AndroidManifest.xml");
+        if (validPathPrefixes.length == 0) {
+            return true;
+        } else {
+            for (String prefix : validPathPrefixes) {
+                if (file.startsWith(prefix)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.jelly
@@ -4,6 +4,10 @@
            description="${%description.pattern('http://ant.apache.org/manual/Types/fileset.html')}">
 	<f:textbox />
   </f:entry>
+  <f:entry title="${%Path prefixes}" field="validPathPrefixes"
+           description="${%description.prefix}">
+    <f:textbox />
+  </f:entry>
   <f:advanced>
     <u:advanced id="androidLint"/>
   </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.properties
@@ -3,3 +3,5 @@ description.pattern=<a href="{0}">Fileset 'includes'</a> \
                  Basedir of the fileset is <a href="ws/">the workspace root</a>. \
                  If no value is set, then the default '**/lint-results.xml' is used. Be sure not to include any \
              non-report files into this pattern.
+description.prefix=Comma-delimited list of valid path prefixes (e.g. "AndroidManifest.xml,src/,res/"). Default is \
+   blank which accepts all paths.

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.jelly
@@ -4,6 +4,10 @@
            description="${%description.pattern('http://ant.apache.org/manual/Types/fileset.html')}">
     <f:textbox />
   </f:entry>
+  <f:entry title="${%Path prefixes}" field="validPathPrefixes"
+           description="${%description.prefix}">
+    <f:textbox />
+  </f:entry>
   <f:advanced>
     <u:advancedMaven id="androidLint"/>
   </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.properties
@@ -3,3 +3,5 @@ description.pattern=<a href="{0}">Fileset 'includes'</a> \
                  Basedir of the fileset is <a href="ws/">the workspace root</a>. \
                  If no value is set, then the default '**/lint-results.xml' is used. Be sure not to include any \
              non-report files into this pattern.
+description.prefix=Comma-delimited list of valid path prefixes (e.g. "AndroidManifest.xml,src/,res/"). Default is \
+   blank which accepts all paths.

--- a/src/test/java/org/jenkinsci/plugins/android_lint/parser/LintParserTest.java
+++ b/src/test/java/org/jenkinsci/plugins/android_lint/parser/LintParserTest.java
@@ -114,7 +114,7 @@ public class LintParserTest extends TestCase {
     }
 
     private List<LintAnnotation> parseResults(String filename) throws InvocationTargetException {
-        LintParser parser = new LintParser("UTF-8");
+        LintParser parser = new LintParser("UTF-8", null);
         InputStream stream = getClass().getResourceAsStream(filename);
         List<LintAnnotation> list = new ArrayList<LintAnnotation>();
         for (FileAnnotation a : parser.parse(stream, MODULE_NAME)) {


### PR DESCRIPTION
I'm building an Android application using Maven on Jenkins. The android-lint-plugin unfortunately also reports issues for the libraries I am using which is distorting the statistics. I did not find a way to filter the libraries' issues while creating the lint report so I added a configuration option to this plugin.

I'm not sure if this use-case is also relevant to other users. Comments greatly appreciated.
