### PR TITLE
Default lint results file pattern changed to be compatible with Android gradle plugin 2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintPublisher.java
@@ -25,7 +25,7 @@ public class LintPublisher extends HealthAwarePublisher {
     private static final String PLUGIN_NAME = "android-lint";
 
     /** Default filename pattern. */
-    private static final String DEFAULT_PATTERN = "**/lint-results.xml";
+    private static final String DEFAULT_PATTERN = "**/lint-results*.xml";
 
     private static final long serialVersionUID = 3435696173660003622L;
 

--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintReporter.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintReporter.java
@@ -26,7 +26,7 @@ public class LintReporter extends HealthAwareReporter<LintResult> {
     private static final String PLUGIN_NAME = "android-lint";
 
     /** Default filename pattern. */
-    private static final String DEFAULT_PATTERN = "**/lint-results.xml";
+    private static final String DEFAULT_PATTERN = "**/lint-results*.xml";
 
     private static final long serialVersionUID = 3712982963880076975L;
 

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.properties
@@ -1,5 +1,5 @@
 description.pattern=<a href="{0}">Fileset 'includes'</a> \
-                 setting that specifies the generated Lint XML report files, such as '**/lint-results.xml'. \
+                 setting that specifies the generated Lint XML report files, such as '**/lint-results*.xml'. \
                  Basedir of the fileset is <a href="ws/">the workspace root</a>. \
-                 If no value is set, then the default '**/lint-results.xml' is used. Be sure not to include any \
+                 If no value is set, then the default '**/lint-results*.xml' is used. Be sure not to include any \
              non-report files into this pattern.

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintReporter/config.properties
@@ -1,5 +1,5 @@
 description.pattern=<a href="{0}">Fileset 'includes'</a> \
-                 setting that specifies the generated Lint XML report files, such as '**/lint-results.xml'. \
+                 setting that specifies the generated Lint XML report files, such as '**/lint-results*.xml'. \
                  Basedir of the fileset is <a href="ws/">the workspace root</a>. \
-                 If no value is set, then the default '**/lint-results.xml' is used. Be sure not to include any \
+                 If no value is set, then the default '**/lint-results*.xml' is used. Be sure not to include any \
              non-report files into this pattern.


### PR DESCRIPTION
`lint-results.xml` is no longer produced by `lint` task.