### PR TITLE
Upated to work with latest version of static analysis plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintDescriptor.java
@@ -3,7 +3,15 @@ package org.jenkinsci.plugins.android_lint;
 import org.jenkinsci.Symbol;
 
 import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.plugins.analysis.core.NullBuildHistory;
 import hudson.plugins.analysis.core.PluginDescriptor;
+import hudson.plugins.analysis.graph.DefaultGraphConfigurationView;
+import hudson.plugins.analysis.graph.GraphConfiguration;
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.StaplerProxy;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Descriptor for the class {@link LintPublisher}.<br>
@@ -13,19 +21,47 @@ import hudson.plugins.analysis.core.PluginDescriptor;
  */
 @Symbol("androidLint")
 @Extension(ordinal = 100)
-public final class LintDescriptor extends PluginDescriptor {
+public final class LintDescriptor extends PluginDescriptor implements StaplerProxy {
 
     /** Used in visible URLs. */
     public static final String PLUGIN_NAME = "androidLint";
+
+    /** The URL of the result action. */
+    public static final String RESULT_URL = PluginDescriptor.createResultUrlName(PLUGIN_NAME);
 
     /** Used to specify location of resources. */
     public static final String PLUGIN_ROOT = "/plugin/android-lint/";
 
     /** Icon to use for the result and project action. */
-    private static final String ACTION_ICON = PLUGIN_ROOT + "icons/android-24x24.png";
+    static final String ACTION_ICON = PLUGIN_ROOT + "icons/android-24x24.png";
 
     public LintDescriptor() {
         super(LintPublisher.class);
+    }
+
+    /**
+     * Returns the graph configuration screen.
+     *
+     * @param link
+     *            the link to check
+     * @param request
+     *            stapler request
+     * @param response
+     *            stapler response
+     * @return the graph configuration or <code>null</code>
+     */
+    public Object getDynamic(final String link, final StaplerRequest request, final StaplerResponse response) {
+        if ("configureDefaults".equals(link)) {
+            Ancestor ancestor = request.findAncestor(AbstractProject.class);
+            if (ancestor.getObject() instanceof AbstractProject) {
+                AbstractProject<?, ?> project = (AbstractProject<?, ?>)ancestor.getObject();
+                return new DefaultGraphConfigurationView(
+                        new GraphConfiguration(LintProjectAction.getAllGraphs()), project, PLUGIN_NAME,
+                        new NullBuildHistory(),
+                        project.getAbsoluteUrl() + "/descriptorByName/LintPublisher/configureDefaults/");
+            }
+        }
+        return null;
     }
 
     @Override
@@ -48,4 +84,8 @@ public final class LintDescriptor extends PluginDescriptor {
         return ACTION_ICON;
     }
 
+    @Override
+    public Object getTarget() {
+        return this;
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/android_lint/LintProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/android_lint/LintProjectAction.java
@@ -3,6 +3,9 @@ package org.jenkinsci.plugins.android_lint;
 import hudson.model.AbstractProject;
 import hudson.plugins.analysis.core.ResultAction;
 import hudson.plugins.analysis.core.AbstractProjectAction;
+import hudson.plugins.analysis.core.PluginDescriptor;
+import hudson.plugins.analysis.graph.BuildResultGraph;
+import java.util.List;
 
 /**
  * Entry point to visualize the trend graph in the project screen.
@@ -10,6 +13,15 @@ import hudson.plugins.analysis.core.AbstractProjectAction;
  * Drawing of the graph is delegated to the associated {@link ResultAction}.
  */
 public class LintProjectAction extends AbstractProjectAction<ResultAction<LintResult>> {
+
+    /**
+     * Returns all the graphs.
+     *
+     * @return the graphs
+     */
+    public static List<BuildResultGraph> getAllGraphs() {
+        return new LintProjectAction(null, null).getAvailableGraphs();
+    }
 
     /**
      * Instantiates a new {@link LintProjectAction}.
@@ -28,9 +40,14 @@ public class LintProjectAction extends AbstractProjectAction<ResultAction<LintRe
      */
     public LintProjectAction(final AbstractProject<?, ?> project,
             final Class<? extends ResultAction<LintResult>> type) {
-        super(project, type, new LintDescriptor());
+        super(project, LintResultAction.class,
+                Messages._AndroidLint_ProjectAction_Name(), Messages._AndroidLint_ProjectAction_TrendName(),
+                LintDescriptor.PLUGIN_NAME,
+                LintDescriptor.ACTION_ICON,
+                LintDescriptor.RESULT_URL);
     }
 
+    @Override
     public String getDisplayName() {
         return Messages.AndroidLint_ProjectAction_Name();
     }

--- a/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/android_lint/LintPublisher/config.jelly
@@ -4,7 +4,10 @@
            description="${%description.pattern('http://ant.apache.org/manual/Types/fileset.html')}">
 	<f:textbox />
   </f:entry>
-  <f:advanced>
-    <u:advanced id="androidLint"/>
-  </f:advanced>
+  <u:health id="androidLint" />
+  <u:thresholds id="androidLint" />
+  <u:defaultEncoding id="androidLint" />
+  <f:entry title="${%Trend graph}">
+    <a href="descriptorByName/LintPublisher/configureDefaults">${%configure}</a>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Hi,

I was using your plugin and noticed that it didn't play so nice with the latest version of Static Code Analysis Plugin.

This patch is based on warnings-plugin and it allows the graph configuration to be opened up from the config page without giving a 404.

It also changes the way the constructor is invoked by LintProjectAction since the current way is marked as deprecated.

-Caleb