### PR TITLE
[JENKINS-49016] - Whitelist AbstractMultimap to make the plugin compatible with 2.102

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+# JENKINS-49016
+com.google.common.collect.AbstractMultimap


### PR DESCRIPTION
Just a hotfix for https://issues.jenkins-ci.org/browse/JENKINS-49016

I suspect it may be not enough, and the real fix is needed on the Analytics Core side. See my comment in the JIRA ticket

@reviewbybees @jglick @uhafner 
